### PR TITLE
Fix draw render debug to use relative coordinates

### DIFF
--- a/objects/oCtrl/Create_0.gml
+++ b/objects/oCtrl/Create_0.gml
@@ -118,16 +118,3 @@ scrollable_container.set({
 		}
 	}),
 });
-
-var layer_with_draggable = new UihLayer({x: 300, y: 300, width: 200, height: 200});
-var draggable_button = new UihDraggable();
-
-draggable_button.add_child(new UiButton({
-	x: 10,
-	y: 10,
-	width: 75,
-	height: 30,
-	text: "Drag me!",
-}));
-
-layer_with_draggable.add_child(draggable_button);

--- a/objects/oCtrl/Create_0.gml
+++ b/objects/oCtrl/Create_0.gml
@@ -1,3 +1,5 @@
+draw_debug = false;
+
 /** Notifications */
 var notification_elem = new UiNotification({ 
 	x: display_get_gui_width() - 340, 
@@ -41,10 +43,10 @@ var primary_checkbox = new UiCheckbox({
 	height: 25, 
 	text: "Enable UI Render Debug",
 	checked: false,
-	on_click: method({ notification_elem: notification_elem }, function(elem) {
+	on_click: method({ ctrl: id, notification_elem: notification_elem }, function(elem) {
 		notification_elem.add_item("Primary checkbox has been pressed", ui_enum_variants.primary);
-		global.UI_ENABLE_RENDER_DEBUG = !global.UI_ENABLE_RENDER_DEBUG;
-		elem.state.text = global.UI_ENABLE_RENDER_DEBUG ? "Disable UI Render Debug" : "Enable UI Render Debug";
+		ctrl.draw_debug = !ctrl.draw_debug;
+		elem.state.text = ctrl.draw_debug ? "Disable UI Render Debug" : "Enable UI Render Debug";
 	})
 });
 
@@ -77,7 +79,7 @@ for (var i = 0; i < 15; i++) {
 		y: i * 50,
 		width: 190,
 		height: 40,
-		text: "Button in scrollable " + string(i),
+		text: "Button " + string(i),
 	}, scrollable_container);
 }
 
@@ -116,3 +118,16 @@ scrollable_container.set({
 		}
 	}),
 });
+
+var layer_with_draggable = new UihLayer({x: 300, y: 300, width: 200, height: 200});
+var draggable_button = new UihDraggable();
+
+draggable_button.add_child(new UiButton({
+	x: 10,
+	y: 10,
+	width: 75,
+	height: 30,
+	text: "Drag me!",
+}));
+
+layer_with_draggable.add_child(draggable_button);

--- a/objects/oCtrl/Draw_64.gml
+++ b/objects/oCtrl/Draw_64.gml
@@ -1,2 +1,6 @@
 // Re-render the elements if updated, and draw their surfaces
-ui_draw();
+var updated_components = ui_draw();
+
+if (draw_debug) {
+	ui_draw_debug(updated_components);
+}

--- a/scripts/__uih_component/__uih_component.gml
+++ b/scripts/__uih_component/__uih_component.gml
@@ -1,6 +1,10 @@
 // Default root layer component
 global.UIH_ROOT_COMPONENT = new UihLayer({ x: 0, y: 0, width: room_width, height: room_height }, { 
 	children: [],
+	state: {
+		scroll_x: 0,
+		scroll_y: 0,
+	},
 	x_abs: function() {
 		return 0;
 	},
@@ -127,7 +131,7 @@ function UihComponent(
 	 * @return {Real}
 	 */
 	x_abs = function() {
-		return parent.x_abs() + state.x;
+		return parent.x_abs() + state.x - parent.state.scroll_x;
 	};
 		 
 	/**
@@ -136,7 +140,7 @@ function UihComponent(
 	 * @return {Real}
 	 */
 	y_abs = function() {
-		return parent.y_abs() + state.y;
+		return parent.y_abs() + state.y - parent.state.scroll_y;
 	};
 	
 	/**

--- a/scripts/ui_draw/ui_draw.gml
+++ b/scripts/ui_draw/ui_draw.gml
@@ -1,6 +1,3 @@
-// Variable to enable the components render debug
-global.UI_ENABLE_RENDER_DEBUG = false;
-
 /**
  * Re-render the childents if updated and draw their surfaces
  * 
@@ -13,6 +10,8 @@ function ui_draw(children = global.UIH_ROOT_COMPONENT.children) {
 	var halign = draw_get_halign();
 	var valign = draw_get_valign();
 	var alpha = draw_get_alpha();
+	
+	var updated_components = [];
 
 	// Loop over the childents
 	for (var i = 0; i < array_length(children); i++) {
@@ -37,23 +36,21 @@ function ui_draw(children = global.UIH_ROOT_COMPONENT.children) {
 			if (child.updated) {
 				surface_set_target(child.surface);
 				draw_clear_alpha(c_black, 0);
+
 				child.draw();
-				ui_draw(child.children);
-				surface_reset_target();
 				child.updated = false;
+
+				surface_reset_target();
 				draw_set_alpha(1);
 
-				// For debug purposes, draw an outline around the rendered component
-				if (global.UI_ENABLE_RENDER_DEBUG) {
-					draw_set_color(c_red);
-					for (var o = 0; o < 3; o++) {
-						draw_rectangle(state.x - o, state.y - o, state.x + state.width + o, state.y + state.height + o, true);
-					}
-				}
+				array_push(updated_components, child);
 			}
 
 			// First draw the children as they can draw on parent's surface
-			ui_draw(child.children);
+			var updated_children = ui_draw(child.children);
+			for (var j = 0; j < array_length(updated_children); j++) {
+				array_push(updated_components, updated_children[j]);
+			}
 
 			// Then draw the surface on its own parent's surface 
 			if (!parent.disable_surface) {
@@ -61,7 +58,8 @@ function ui_draw(children = global.UIH_ROOT_COMPONENT.children) {
 				draw_surface(child.surface, child.state.x - parent.state.scroll_x, child.state.y - parent.state.scroll_y);
 				surface_reset_target();
 			} else {
-				draw_surface(child.surface, parent.x_abs() + child.state.x - parent.state.scroll_x, parent.y_abs() + child.state.y - parent.state.scroll_y); // TODO: improve this, parents without surface can cause issues
+				// TODO: improve this, parents without surface can cause issues and require custom drawing with absolute coordinates
+				draw_surface(child.surface, parent.x_abs() + child.state.x - parent.state.scroll_x, parent.y_abs() + child.state.y - parent.state.scroll_y);
 			}
 		} else {
 			ui_draw(child.children);
@@ -74,4 +72,6 @@ function ui_draw(children = global.UIH_ROOT_COMPONENT.children) {
 	draw_set_halign(halign);
 	draw_set_valign(valign);
 	draw_set_alpha(alpha);
+	
+	return updated_components;
 }

--- a/scripts/ui_draw/ui_draw.gml
+++ b/scripts/ui_draw/ui_draw.gml
@@ -48,7 +48,7 @@ function ui_draw(children = global.UIH_ROOT_COMPONENT.children) {
 
 			// First draw the children as they can draw on parent's surface
 			var updated_children = ui_draw(child.children);
-			for (var j = 0; j < array_length(updated_children); j++) {
+			for (var j = 0, jlen = array_length(updated_children); j < jlen; j++) {
 				array_push(updated_components, updated_children[j]);
 			}
 

--- a/ui.yyp
+++ b/ui.yyp
@@ -17,6 +17,7 @@
     {"id":{"name":"ui_scrollbar","path":"scripts/ui_scrollbar/ui_scrollbar.yy",},"order":5,},
     {"id":{"name":"ui_scrollable_container","path":"scripts/ui_scrollable_container/ui_scrollable_container.yy",},"order":6,},
     {"id":{"name":"oCtrl","path":"objects/oCtrl/oCtrl.yy",},"order":0,},
+    {"id":{"name":"ui_draw_debug","path":"scripts/ui_draw_debug/ui_draw_debug.yy",},"order":3,},
   ],
   "Options": [
     {"name":"Android","path":"options/android/options_android.yy",},


### PR DESCRIPTION
- update function `ui_draw`:
  - it does not draw render debug anymore
  - it now return an array containing the updated component
- add function `ui_draw_debug` to draw render debug for the given components
- remove global variable UI_ENABLE_RENDER_DEBUG
- remove duplicated `ui_draw` call
- take into account scroll offsets in `x_abs` and `y_abs` methods